### PR TITLE
feat: Allow aliases to include default prompt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See also [the llm tag](https://simonwillison.net/tags/llm/) on my blog.
 * [Model aliases](https://llm.datasette.io/en/stable/aliases.html)
   * [Listing aliases](https://llm.datasette.io/en/stable/aliases.html#listing-aliases)
   * [Adding a new alias](https://llm.datasette.io/en/stable/aliases.html#adding-a-new-alias)
+  * [Alias with prompt options](https://llm.datasette.io/en/stable/aliases.html#aliases-with-options)
   * [Removing an alias](https://llm.datasette.io/en/stable/aliases.html#removing-an-alias)
   * [Viewing the aliases file](https://llm.datasette.io/en/stable/aliases.html#viewing-the-aliases-file)
 * [Embeddings](https://llm.datasette.io/en/stable/embeddings/index.html)

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -100,6 +100,46 @@ The `llm aliases remove <alias>` command will remove the specified alias:
 llm aliases remove mini
 ```
 
+## Aliases with options
+
+You can save default prompt options with an alias. For example, to create an alias `4o-creative` that always uses `gpt-4o` with a high temperature, you can do this:
+
+```bash
+llm aliases set 4o-creative gpt-4o -o temperature 1.5
+```
+
+Then you can use this alias like so:
+
+```bash
+llm -m 4o-creative 'Write a creative story about a robot'
+```
+
+The model will be called with the `temperature` option set to `1.5`.
+
+If you specify options both in the alias and on the command line, the command-line options will take precedence.
+
+For example:
+
+```bash
+llm -m 4o-creative -o temperature 1.0 'Write a creative story about a robot'
+```
+
+This will override the alias temperature setting.
+
+### OpenRouter plugin example
+
+You can also create aliases for plugin models. Here is an example with openrouter provider configurations:
+
+```bash
+llm aliases set maverick-lowlatency openrouter/meta-llama/llama-4-maverick -o provider '{
+  "order": [
+    "Baseten", 
+    "Parasail"
+  ],
+"allow_fallbacks": false
+}'
+```
+
 ## Viewing the aliases file
 
 Aliases are stored in an `aliases.json` file in the LLM configuration directory.


### PR DESCRIPTION
I implemented support for defining aliases with embedded default prompt options. This enables users to pre-configure common model parameters with an alias.

Key changes include:
- Modified `llm aliases set` to accept `-o`/`--option` arguments, allowing options to be stored with the alias.
- Updated `llm prompt` and `llm chat` commands to resolve and apply options defined within an alias. Command-line options now take precedence over alias-defined options.
- Adjusted alias configuration parsing to be backward compatible, supporting both the new dictionary format (model and options) and the old string format.
- Added comprehensive documentation for the new alias options feature.
